### PR TITLE
✨Sauvegarder actions jaunes du patient

### DIFF
--- a/raimed2Back/src/main/java/fr/imt/raimed2/action/dto/xml/ActionDTO.java
+++ b/raimed2Back/src/main/java/fr/imt/raimed2/action/dto/xml/ActionDTO.java
@@ -26,4 +26,7 @@ public class ActionDTO implements Serializable {
 
     @JacksonXmlProperty(localName = "actionPrescription")
     private ActionPrescriptionDTO actionPrescriptionDTO;
+
+    @JacksonXmlProperty(localName = "actionExamen")
+    private ActionExamenDTO actionExamenDTO;
 }

--- a/raimed2Back/src/main/java/fr/imt/raimed2/action/dto/xml/ActionExamenDTO.java
+++ b/raimed2Back/src/main/java/fr/imt/raimed2/action/dto/xml/ActionExamenDTO.java
@@ -1,0 +1,19 @@
+package fr.imt.raimed2.action.dto.xml;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+public class ActionExamenDTO implements Serializable {
+    @JacksonXmlProperty
+    private String zone;
+
+    @JacksonXmlProperty(localName = "signs")
+    private String signs;
+
+}

--- a/raimed2Back/src/main/java/fr/imt/raimed2/action/model/ActionExamen.java
+++ b/raimed2Back/src/main/java/fr/imt/raimed2/action/model/ActionExamen.java
@@ -1,0 +1,26 @@
+package fr.imt.raimed2.action.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@Getter
+@Setter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@DiscriminatorValue("EXAMEN")
+public class ActionExamen extends Action {
+
+    @Column(name = "zone")
+    private String zone;
+
+    @Column(name = "signs")
+    private String signs;
+}

--- a/raimed2Back/src/main/java/fr/imt/raimed2/action/repository/ActionExamenRepository.java
+++ b/raimed2Back/src/main/java/fr/imt/raimed2/action/repository/ActionExamenRepository.java
@@ -1,0 +1,7 @@
+package fr.imt.raimed2.action.repository;
+
+import fr.imt.raimed2.action.model.ActionExamen;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActionExamenRepository extends JpaRepository<ActionExamen, Long> {
+}

--- a/raimed2Back/src/main/java/fr/imt/raimed2/action/service/ActionService.java
+++ b/raimed2Back/src/main/java/fr/imt/raimed2/action/service/ActionService.java
@@ -3,6 +3,7 @@ package fr.imt.raimed2.action.service;
 import fr.imt.raimed2.action.dto.request.CreateActionSpontaneousPatientSpeech;
 import fr.imt.raimed2.action.dto.xml.*;
 import fr.imt.raimed2.action.model.ActionClosedQuestion;
+import fr.imt.raimed2.action.model.ActionExamen;
 import fr.imt.raimed2.action.model.ActionOpenedQuestion;
 import fr.imt.raimed2.action.model.ActionPrescription;
 import fr.imt.raimed2.action.model.ActionSpontaneousPatientSpeech;
@@ -160,5 +161,16 @@ public class ActionService {
         actionOpenedQuestion.setPrimaryElement(actionDTO.getPrimaryElement());
         actionOpenedQuestion.setVirtualPatient(virtualPatient);
         return actionOpenedQuestionRepository.save(actionOpenedQuestion);
+    }
+
+    public void saveActionExamen(VirtualPatient virtualPatient, ActionDTO actionDTO) {
+        ActionExamen actionExamen = new ActionExamen();
+        actionExamen.setVirtualPatient(virtualPatient);
+        actionExamen.setPrimaryElement(actionDTO.getPrimaryElement());
+        actionExamen.setType(actionDTO.getType());
+        actionExamen.setZone(actionDTO.getActionExamenDTO().getZone());
+        actionExamen.setSigns(actionDTO.getActionExamenDTO().getSigns());
+
+        actionRepository.save(actionExamen);
     }
 }

--- a/raimed2Back/src/main/java/fr/imt/raimed2/virtualPatient/service/VirtualPatientService.java
+++ b/raimed2Back/src/main/java/fr/imt/raimed2/virtualPatient/service/VirtualPatientService.java
@@ -57,6 +57,9 @@ public class VirtualPatientService {
                 if(actionDTO.getActionOpenedQuestionDTO() != null){
                     actionService.saveActionOpenedQuestion(saved, actionDTO);
                 }
+                if (actionDTO.getActionExamenDTO() != null) {
+                    actionService.saveActionExamen(saved, actionDTO);
+                }
             }
         }catch(DataIntegrityViolationException ex){
             System.out.println(ex.getMessage());

--- a/raimed2Back/src/main/resources/db/migration/V0.0.9__alter_action_data_structure.sql
+++ b/raimed2Back/src/main/resources/db/migration/V0.0.9__alter_action_data_structure.sql
@@ -1,0 +1,2 @@
+ALTER TABLE raimed_action ADD COLUMN zone VARCHAR(255);
+ALTER TABLE raimed_action ADD COLUMN signs VARCHAR(255);

--- a/raimed2Front/src/stores/patient.store.ts
+++ b/raimed2Front/src/stores/patient.store.ts
@@ -11,6 +11,7 @@ import {useAuthStore} from '@/stores/auth.store';
 import type {Listen} from "@/models/listen/listen.model";
 import type {Question} from "@/models/question/question.model";
 import type {Prescription} from "@/models/prescription/prescription.model";
+import type {ExamResults} from "@/models/diagnostic/exam.model";
 
 interface PatientState {
   virtualPatients: VirtualPatient[];
@@ -90,7 +91,11 @@ function createVirtualPatient(newPatient: NewPatient) {
                 ...newPatient.listen.map(createSpontaneousPatientSpeechAction),
                 ...newPatient.biology.map(createBiologyPrescriptionAction),
                 ...newPatient.biopsy.map(createBiopsyPrescriptionAction),
-                ...newPatient.imagery.map(createImageryPrescriptionAction)
+                ...newPatient.imagery.map(createImageryPrescriptionAction),
+                ...newPatient.inspection.map(result => createExamenAction(result, TypeAction.INSPECTION)),
+                ...newPatient.palpation.map(result => createExamenAction(result, TypeAction.PALPATION)),
+                ...newPatient.percussion.map(result => createExamenAction(result, TypeAction.PERCUSSION)),
+                ...newPatient.auscultation.map(result => createExamenAction(result, TypeAction.AUSCULTATION))
             ]
         }
     };
@@ -162,4 +167,15 @@ function createQuestionActions(questions: Question[]) {
       },
     }),
   }));
+}
+
+function createExamenAction(examResult: ExamResults, type: TypeAction) {
+  return {
+    type: type,
+    primaryElement: examResult.zone,
+    actionExamen: {
+      zone: examResult.zone,
+      signs: examResult.signs,
+    }
+  };
 }


### PR DESCRIPTION
Proposition pour récuperer le patient et ses actions

J'ai du faire des ptites modifs pour éviter les bugs

## Description

Sauvegarde des examens (actions jaunes) dans la table action de raimed.

## Type de changement

- [x] Nouvelle fonctionnalité

## Checklist

- [x ] Tous les tests unitaires passent
- [x ] Le code compile et se lance chez vous en local
- [x ] Ticket Jira complété